### PR TITLE
fix(fields): correctly compute container classname

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -316,9 +316,7 @@ function plugin_datainjection_populate_fields() {
       $types = json_decode($values['itemtypes']);
 
       foreach ($types as $type) {
-         $classname = "PluginFields"
-                     . ucfirst($type. preg_replace('/s$/', '', $values['name']))
-                     . 'Injection';
+         $classname = PluginFieldsContainer::getClassname($type, $values['name']). 'Injection';
          $INJECTABLE_TYPES[$classname] = 'fields';
       }
    }

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1546,6 +1546,7 @@ class PluginFieldsContainer extends CommonDBTM {
 
       $i = 76665;
 
+      $escaped_itemtype = $DB->escape(addslashes(addslashes($itemtype)));
       $query = "SELECT DISTINCT fields.id, fields.name, fields.label, fields.type, fields.is_readonly,
             containers.name as container_name, containers.label as container_label,
             containers.itemtypes, containers.id as container_id, fields.id as field_id
@@ -1557,9 +1558,10 @@ class PluginFieldsContainer extends CommonDBTM {
          INNER JOIN glpi_plugin_fields_fields fields
             ON containers.id = fields.plugin_fields_containers_id
             AND containers.is_active = 1
-         WHERE containers.itemtypes LIKE '%$itemtype%'
+         WHERE containers.itemtypes LIKE '%$escaped_itemtype%'
             AND fields.type != 'header'
             ORDER BY fields.id ASC";
+
       $res = $DB->query($query);
       while ($data = $DB->fetchAssoc($res)) {
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -591,9 +591,9 @@ class PluginFieldsContainer extends CommonDBTM {
             $classname::uninstall();
          } else {
             //class does not exists; try to remove any existing table
-            $tablename = "glpi_plugin_fields_" . strtolower(
-               $itemtype . getPlural(preg_replace('/s$/', '', $this->fields['name']))
-            );
+            $tablename = "glpi_plugin_fields_" . strtolower(str_replace('\\', '', $itemtype) . getPlural(preg_replace('/s$/', '', $container->fields['name'])));
+
+
             $DB->query("DROP TABLE IF EXISTS `$tablename`");
          }
 
@@ -1261,9 +1261,8 @@ class PluginFieldsContainer extends CommonDBTM {
          } else if (isset($data['plugin_fields_'.$name.'dropdowns_id'])) {
             $value = $data['plugin_fields_'.$name.'dropdowns_id'];
          } else if ($field['mandatory'] == 1) {
-            $tablename = "glpi_plugin_fields_" . strtolower(
-               $itemtype . getPlural(preg_replace('/s$/', '', $container->fields['name']))
-            );
+
+            $tablename = "glpi_plugin_fields_" . strtolower(str_replace('\\', '', $itemtype) . getPlural(preg_replace('/s$/', '', $container->fields['name'])));
 
             $query = "SELECT * FROM `$tablename` WHERE
                `itemtype`='$itemtype'
@@ -1572,8 +1571,7 @@ class PluginFieldsContainer extends CommonDBTM {
             }
          }
 
-         $tablename = "glpi_plugin_fields_".strtolower($itemtype.
-                        getPlural(preg_replace('/s$/', '', $data['container_name'])));
+         $tablename = "glpi_plugin_fields_" . strtolower(str_replace('\\', '', $itemtype) . getPlural(preg_replace('/s$/', '', $data['container_name'])));
 
          //get translations
          $container = [

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -698,8 +698,7 @@ class PluginFieldsField extends CommonDBTM {
          }
       }
 
-      $classname = "PluginFields".$itemtype.
-                                 preg_replace('/s$/', '', $container_obj->fields['name']);
+      $classname = PluginFieldsContainer::getClassname($itemtype, $container_obj->fields['name']);
       $obj = new $classname;
 
       //find row for this object with the items_id


### PR DESCRIPTION
Prevent error when fields are displayed

```shell
  
[2022-05-02 10:29:35] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class 'PluginFieldsGlpi\SocketModeltab' not found in /home//dev/GLPI/10.0-bugfixes/plugins/fields/inc/field.class.php at line 703
  Backtrace :
  plugins/fields/inc/field.class.php:546             PluginFieldsField::prepareHtmlFields()
  plugins/fields/inc/container.class.php:1066        PluginFieldsField::showForTabContainer()
  src/CommonGLPI.php:687                             PluginFieldsContainer::displayTabContentForItem()
  ajax/common.tabs.php:107                           CommonGLPI::displayStandardTab()
```